### PR TITLE
Fixing Issue #4 - 'Teardown fails for EndToEndHelper if data still exists in the GCS bucket' by deleting all the files first before deleting the bucket.

### DIFF
--- a/src/main/java/com/google/cloud/pontem/EndToEndHelper.java
+++ b/src/main/java/com/google/cloud/pontem/EndToEndHelper.java
@@ -29,6 +29,7 @@ import com.google.cloud.spanner.SpannerException;
 import com.google.cloud.spanner.SpannerOptions;
 import com.google.cloud.spanner.Struct;
 import com.google.cloud.spanner.Value;
+import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.Storage;
@@ -236,8 +237,13 @@ public class EndToEndHelper {
     StorageOptions.Builder optionsBuilder = StorageOptions.newBuilder();
     StorageOptions storageOptions = optionsBuilder.setProjectId(projectId).build();
     Storage storage = storageOptions.getService();
-    Bucket bucket = storage.get(gcsBucketName);
-    bucket.delete(Bucket.BucketSourceOption.metagenerationMatch());
+
+    Iterable<Blob> blobs = storage.list(gcsBucketName, Storage.BlobListOption.prefix("")).iterateAll();
+    for (Blob blob : blobs) {
+      blob.delete(Blob.BlobSourceOption.generationMatch());
+    }
+
+    storage.delete(gcsBucketName, Storage.BucketSourceOption.userProject(projectId));
   }
 
   private static void createCloudSpannerDatabaseAndTableStructure(


### PR DESCRIPTION
Closes #4 