### PR TITLE
Add --region to command lines, and mention in Performance

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -59,6 +59,7 @@ mvn compile exec:java \
                --inputSpannerDatabaseId=words2 \
                --outputFolder=gs://my-cloud-spanner-project/backups/latest \
                --projectId=my-cloud-spanner-project" \
+               --region=us-central1 \
   -Pdataflow-runner
 ```
 
@@ -76,6 +77,7 @@ mvn compile exec:java \
                --projectId=my-cloud-spanner-project \
                --shouldQueryTableRowCounts=true \
                --shouldQueryTableSchema=false" \
+               --region=us-central1 \
   -Pdataflow-runner
 ```
 
@@ -86,6 +88,7 @@ A simple sample run:
 mvn compile exec:java \
      -Dexec.mainClass=com.google.cloud.pontem.CloudSpannerDatabaseBackupIntegrityCheck \
      -Dexec.args="--project=my-cloud-spanner-project \
+                  --region=us-central1 \
                   --databaseBackupLocation=gs://my-cloud-spanner-project/multi-backup \
                   --job=2017-10-25_11_18_28-6233650047978038157"
 ```
@@ -96,6 +99,7 @@ A sample run that requires checking row counts against the meta-data file:
 mvn compile exec:java \
      -Dexec.mainClass=com.google.cloud.pontem.CloudSpannerDatabaseBackupIntegrityCheck \
      -Dexec.args="--project=my-cloud-spanner-project \
+                  --region=us-central1 \
                   --databaseBackupLocation=gs://my-cloud-spanner-project/multi-backup \
                   --job=2017-10-25_11_18_28-6233650047978038157 \
                   --checkRowCountsAgainstGcsMetadataFile=true"
@@ -109,6 +113,7 @@ mvn compile exec:java \
   -Dexec.mainClass=com.google.cloud.pontem.CloudSpannerDatabaseRestore \
   -Dexec.args="--runner=DataflowRunner \
                --project=my-cloud-spanner-project \
+               --region=us-central1 \
                --gcpTempLocation=gs://my-cloud-spanner-project/tmp \
                --outputSpannerInstanceId=my-cloud-spanner-project-db \
                --outputSpannerDatabaseId=words2 \
@@ -126,6 +131,7 @@ mvn compile exec:java \
   -Dexec.mainClass=com.google.cloud.pontem.CloudSpannerDatabaseRestore \
   -Dexec.args="--runner=DataflowRunner \
                --project=my-cloud-spanner-project \
+               --region=us-central1 \
                --gcpTempLocation=gs://my-cloud-spanner-project/tmp \
                --outputSpannerInstanceId=my-cloud-spanner-project-db \
                --outputSpannerDatabaseId=words2 \
@@ -142,6 +148,7 @@ A sample run:
 mvn compile exec:java \
   -Dexec.mainClass=com.google.cloud.pontem.CloudSpannerDatabaseRestoreIntegrityCheck \
   -Dexec.args="--project=my-cloud-spanner-project \
+               --region=us-central1 \
                --backupJobId=2017-12-28_08_21_49-14004506096652894727 \
                --restoreJobId=2017-12-28_10_43_41-10818313728228686289 \
                --restoreJobId=2017-12-28_10_46_20-2492938473109299932 \
@@ -160,6 +167,7 @@ A sample run that requires every table to have been restored:
 mvn compile exec:java \
   -Dexec.mainClass=com.google.cloud.pontem.CloudSpannerDatabaseRestoreIntegrityCheck \
   -Dexec.args="--project=my-cloud-spanner-project \
+               --region=us-central1 \
                --backupJobId=2017-12-28_08_21_49-14004506096652894727 \
                --restoreJobId=2017-12-28_10_43_41-10818313728228686289 \
                --restoreJobId=2017-12-28_10_46_20-2492938473109299932 \
@@ -187,6 +195,9 @@ If the CPU usage is over 75%, it is likely worth increasing your [node count](ht
 In general, the more Dataflow workers you use for a backup, the better.
 In restoring a database, if you're Cloud Spanner CPU is above 75% and you cannot increase your Cloud Spanner node count,
 consider limiting the Dataflow worker count using the ``--maxNumWorkers`` flag.
+
+4. Run everything in the same region
+Ensure that the Spanner database, Dataflow workers and cloud storage bucket are all in the same region to ensure that no cross-region traffic occurs. 
 
 ## Benchmarks
 The times to perform backup and restore will vary dramatically based upon on Cloud Spanner node count, Dataflow worker count, persistent disk available to Dataflow, and the number of parent-child tables. For example, if you have a parent-child table, the parent will need to be restored first before the child can even begin being restored.

--- a/USAGE.md
+++ b/USAGE.md
@@ -54,12 +54,12 @@ mvn compile exec:java \
   -Dexec.mainClass=com.google.cloud.pontem.CloudSpannerDatabaseBackup \
   -Dexec.args="--runner=DataflowRunner \
                --project=my-cloud-spanner-project \
+               --region=us-central1 \
                --gcpTempLocation=gs://my-cloud-spanner-project/tmp \
                --inputSpannerInstanceId=my-cloud-spanner-project-db \
                --inputSpannerDatabaseId=words2 \
                --outputFolder=gs://my-cloud-spanner-project/backups/latest \
                --projectId=my-cloud-spanner-project" \
-               --region=us-central1 \
   -Pdataflow-runner
 ```
 
@@ -70,6 +70,7 @@ mvn compile exec:java \
   -Dexec.mainClass=com.google.cloud.pontem.CloudSpannerDatabaseBackup \
   -Dexec.args="--runner=DataflowRunner \
                --project=my-cloud-spanner-project \
+               --region=us-central1 \
                --gcpTempLocation=gs://my-cloud-spanner-project/tmp \
                --inputSpannerInstanceId=my-cloud-spanner-project-db \
                --inputSpannerDatabaseId=words2 \
@@ -77,7 +78,6 @@ mvn compile exec:java \
                --projectId=my-cloud-spanner-project \
                --shouldQueryTableRowCounts=true \
                --shouldQueryTableSchema=false" \
-               --region=us-central1 \
   -Pdataflow-runner
 ```
 
@@ -183,21 +183,23 @@ mvn compile exec:java \
 
 # Performance
 ## General Performance Tips
-1. Examine the [Google Cloud IAM Quotas page](https://console.cloud.google.com/iam-admin/quotas)
-Look in particular for quotas that are maxed-out (i.e., showing in deep orange). If you have maxed out your Dataflow worker count, you will need more "CPUs (all regions)", "In-use IP addresses", and "CPUs".
+1. Examine the [Google Cloud IAM Quotas page](https://console.cloud.google.com/iam-admin/quotas).
+
+    Look in particular for quotas that are maxed-out (i.e., showing in deep orange). If you have maxed out your Dataflow worker count, you will need more "CPUs (all regions)", "In-use IP addresses", and "CPUs".
 
 Look also for "Persistent Disk Standard (GB)".
 
-2. Examine your Cloud Spanner CPU
-If the CPU usage is over 75%, it is likely worth increasing your [node count](https://cloud.google.com/spanner/docs/instances#node_count). Otherwise, the limiting factor is likely somewhere else.
+2. Examine your Cloud Spanner CPU.
 
-3. Optimizing Dataflow Worker Count
-In general, the more Dataflow workers you use for a backup, the better.
-In restoring a database, if you're Cloud Spanner CPU is above 75% and you cannot increase your Cloud Spanner node count,
-consider limiting the Dataflow worker count using the ``--maxNumWorkers`` flag.
+    If the CPU usage is over 75%, it is likely worth increasing your [node count](https://cloud.google.com/spanner/docs/instances#node_count). Otherwise, the limiting factor is likely somewhere else.
 
-4. Run everything in the same region
-Ensure that the Spanner database, Dataflow workers and cloud storage bucket are all in the same region to ensure that no cross-region traffic occurs. 
+3. Optimizing Dataflow Worker Count.
+
+    In general, the more Dataflow workers you use for a backup, the better. In restoring a database, if you're Cloud Spanner CPU is above 75% and you cannot increase your Cloud Spanner node count, consider limiting the Dataflow worker count using the ``--maxNumWorkers`` flag.
+
+4. Run everything in the same region.
+
+    Ensure that the Cloud Spanner database instance, Dataflow workers and Cloud Storage bucket are all in the same region to prevent any cross-region traffic. 
 
 ## Benchmarks
 The times to perform backup and restore will vary dramatically based upon on Cloud Spanner node count, Dataflow worker count, persistent disk available to Dataflow, and the number of parent-child tables. For example, if you have a parent-child table, the parent will need to be restored first before the child can even begin being restored.


### PR DESCRIPTION
Add a --region command line arg with the default value of us-central1 as an indication to users where they should change it (for #72)

Also add an entry in performance tips on regions.

Also correctly format and punctuate the markdown in the performance tips section.