### PR TITLE
Switching from Cobertura to JaCoCo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ jobs:
     script: mvn checkstyle:checkstyle
   - stage: UNIT_TESTS
     script: mvn -q clean test
-    script: mvn -q cobertura:cobertura
   - stage: E2E_TESTS
     script: "./travis/run_e2e_tests.sh --project=${E2E_TEST_PROJECT_NAME} --bucket=${E2E_TEST_BUCKET}
       --database=${E2E_TEST_DATABASE}"

--- a/pom.xml
+++ b/pom.xml
@@ -64,15 +64,41 @@
             </plugin>
             <!-- Adding code coverage plugin -->
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>cobertura-maven-plugin</artifactId>
-                <version>2.7</version>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.1</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>post-unit-test</id>
+                            <phase>test</phase>
+                            <goals>
+                                <goal>report</goal>
+                            </goals>
+                            <configuration>
+                                <!-- Sets the path to the file which contains the execution data. -->
+                                <dataFile>target/jacoco.exec</dataFile>
+                                <!-- Sets the output directory for the code coverage report. -->
+                                <outputDirectory>target/site/jacoco-ut</outputDirectory>
+                            </configuration>
+                    </execution>
+                </executions>
                 <configuration>
-                    <formats>
-                        <format>html</format>
-                        <format>xml</format>
-                   </formats>
-                   <check />
+                    <systemPropertyVariables>
+		        <jacoco-agent.destfile>target/jacoco.exec</jacoco-agent.destfile>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
tl:dr; - Cobertura does not play nice with Java 8, so switched to JaCoCo

The first sign of trouble with Cobertura was "WARNING No files found in report." in logs in Codecov.io (e.g., https://codecov.io/gh/GoogleCloudPlatform/pontem/commit/5c74ef21e30d0f8f3bef44521c34513c7af02047 ).

When running "mvn cobertura:cobertura" locally, I got a report but the report was blank. Logs said "Cobertura: Loaded information on 0 classes." Based upon a lot of looking and https://stackoverflow.com/questions/25293433/coberturainstrumenter-unable-to-instrument-file/25382674 I realized that Cobertura does not play nice with Java 8, so I switched to JaCoCo


== Codecov.io logs ==
May 15 13:50:20 [INFO] INFO GitHub HTTP 200 {"bot": "n/a", "commit": "5c74ef2", "endpoint": "/search/issues", "event": "api", "method": "GET", "public": "t", "rlr": "1526406680", "rlx": "29", "rly": "30", "service": "github", "slug": "GoogleCloudPlatform/pontem", "task": "upload"}
May 15 13:50:20 [INFO] INFO Retrieved report for processing. {"bot": "n/a", "commit": "5c74ef2", "public": "t", "service": "github", "slug": "GoogleCloudPlatform/pontem", "task": "upload", "url": "v4/raw/2018-05-15/4BF1A79D88D48CE6E7584A8A3B2D4547/5c74ef21e30d0f8f3bef44521c34513c7af02047/c78759c7-1be3-441a-9d3e-7787da8b762a.txt"}
May 15 13:50:20 [INFO] INFO Yaml discovered {"bot": "n/a", "commit": "5c74ef2", "path": ".codecov.yml", "public": "t", "service": "github", "slug": "GoogleCloudPlatform/pontem", "task": "upload"}
May 15 13:50:20 [INFO] INFO Yaml exists at current location. {"bot": "n/a", "commit": "5c74ef2", "public": "t", "service": "github", "slug": "GoogleCloudPlatform/pontem", "task": "upload"}
May 15 13:50:20 [WARNING] WARNING No files found in report. {"bot": "n/a", "commit": "5c74ef2", "public": "t", "service": "github", "slug": "GoogleCloudPlatform/pontem", "task": "upload"}