### PR TITLE
Updating Travis config so as to run E2E Tests in parallel (#119)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,8 @@ jobs:
   - stage: UNIT_TESTS
     script: mvn -q clean test
   - stage: E2E_TESTS
-    script: "./travis/run_e2e_tests.sh --project=${E2E_TEST_PROJECT_NAME} --bucket=${E2E_TEST_BUCKET}
-      --database=${E2E_TEST_DATABASE}"
+    script: "./travis/run_e2e_tests.sh --test_suite=Avro --project=${E2E_TEST_PROJECT_NAME} --bucket=${E2E_TEST_BUCKET} --database=${E2E_TEST_DATABASE}"
+  - script: "./travis/run_e2e_tests.sh --test_suite=Serialized --project=${E2E_TEST_PROJECT_NAME} --bucket=${E2E_TEST_BUCKET} --database=${E2E_TEST_DATABASE}"
+
 after_success:
 - bash <(curl -s https://codecov.io/bash)

--- a/travis/run_e2e_tests.sh
+++ b/travis/run_e2e_tests.sh
@@ -17,6 +17,10 @@
 for i in "$@"
 do
 case $i in
+    -t=*|--test_suite=*)
+    TEST_SUITE="${i#*=}"
+    shift # past argument=value
+    ;;
     -p=*|--project=*)
     GCP_PROJECT="${i#*=}"
     shift # past argument=value
@@ -38,6 +42,13 @@ case $i in
     ;;
 esac
 done
+
+if [ -z ${TEST_SUITE} ]; then
+  echo "No test suite set."
+  exit 1
+else
+  echo "Test Suite Set: ${TEST_SUITE}"
+fi
 
 if [ -z ${GCP_PROJECT} ]; then
   echo "No project set."
@@ -69,8 +80,14 @@ echo "Database Name Set: ${DATABASE_NAME}"
 GCP_FOLDER="my-database-"${DATE_STR}
 echo "GCP Folder Name Set: ${GCP_FOLDER}"
 
-./travis/run_avro_e2e_tests.sh --project="${GCP_PROJECT}" --bucket="${GCP_BUCKET}" --database="${DATABASE_INSTANCE}" &&
-./travis/run_serialized_e2e_tests.sh --project="${GCP_PROJECT}" --bucket="${GCP_BUCKET}" --database="${DATABASE_INSTANCE}" || exit 0
+if [ "${TEST_SUITE}" = "Serialized" ]; then
+  ./travis/run_serialized_e2e_tests.sh --project="${GCP_PROJECT}" --bucket="${GCP_BUCKET}" --database="${DATABASE_INSTANCE}" 
+elif [ "${TEST_SUITE}" = "Avro" ]; then 
+  ./travis/run_avro_e2e_tests.sh --project="${GCP_PROJECT}" --bucket="${GCP_BUCKET}" --database="${DATABASE_INSTANCE}" 
+else
+  echo "Invalid Test Suite"
+  exit 1
+fi
 
-echo "FINISHED Avro and Serialized - All Tests Passed Successfully"
+echo "${TEST_SUITE} Tests Passed Successfully"
 exit 0


### PR DESCRIPTION
* Invoking Avro and Serialized E2E tests in the same stage so that they can be run in parallel. 
   Note: Commands run in a Travis stage are run in parallel and stages themselves are sequential.
* Updated our runner script to run the correct test suite based on the corresponding
parameter.