### PR TITLE
[Root] Updating Travis config so that each project has it's own build stages.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,26 +33,28 @@ stages:
 - E2E_TESTS
 jobs:
   include:
-  - stage: STYLE # Checkstyle is actually included in Gradle's build task but an independent run allows for much cleaner output
-    # BigQueryWorkloadTester
+  - stage: BIQUERY_WORKLOAD_TESTER_STYLE # Checkstyle is actually included in Gradle's build task but an independent run allows for much cleaner output
     if: commit_message =~ /(\[BigQueryWorkloadTester\]|\[Root\])/ OR commit_message !~ /(\[BigQueryWorkloadTester\]|\[CloudSpannerBackupRestore\]|\[CloudSQLReplicator\]|\[Root\])/ # If no tag is matched run everything
     script: 
     - gradle clean :BigQueryWorkloadTester:check
-    # CloudSpannerBackupRestore
+
+  - stage: CLOUD_SPANNER_BACKUP_RESTORE_STYLE # Checkstyle is actually included in Gradle's build task but an independent run allows for much cleaner output
     if: commit_message =~ /(\[CloudSpannerBackupRestore\]|\[Root\])/ OR commit_message !~ /(\[BigQueryWorkloadTester\]|\[CloudSpannerBackupRestore\]|\[CloudSQLReplicator\]|\[Root\])/ # If no tag is matched run everything
     script: 
     - gradle clean :CloudSpannerBackupRestore:check
-  - stage: BUILD_TEST_AND_COVERAGE
-    # BigQueryWorkloadTester
+
+  - stage: BIQUERY_WORKLOAD_TESTER_BUILD_TEST_AND_COVERAGE
     if: commit_message =~ /(\[BigQueryWorkloadTester\]|\[Root\])/ OR commit_message !~ /(\[BigQueryWorkloadTester\]|\[CloudSpannerBackupRestore\]|\[CloudSQLReplicator\]|\[Root\])/ # If no tag is matched run everything
     script:
     - gradle clean :BigQueryWorkloadTester:build :BigQueryWorkloadTester:jacocoTestReport --info --stacktrace 
     - bash <(curl -s https://codecov.io/bash) -f BigQueryWorkloadTester/$JACOCO_REPORT_PATH -F BigQueryWorkloadTester
-    # CloudSpannerBackupRestore
+
+  - stage: CLOUD_SPANNER_BACKUP_RESTORE_BUILD_TEST_AND_COVERAGE
     if: commit_message =~ /(\[CloudSpannerBackupRestore\]|\[Root\])/ OR commit_message !~ /(\[BigQueryWorkloadTester\]|\[CloudSpannerBackupRestore\]|\[CloudSQLReplicator\]|\[Root\])/ # If no tag is matched run everything
     script:
     - gradle clean :CloudSpannerBackupRestore:build :CloudSpannerBackupRestore:jacocoTestReport --info --stacktrace 
     - bash <(curl -s https://codecov.io/bash) -f CloudSpannerBackupRestore/$JACOCO_REPORT_PATH -F CloudSpannerBackupRestore
-  - stage: E2E_TESTS
+
+  - stage: CLOUD_SPANNER_BACKUP_RESTORE_E2E_TESTS
     if: commit_message =~ /(\[CloudSpannerBackupRestore\]|\[Root\])/ OR commit_message !~ /(\[BigQueryWorkloadTester\]|\[CloudSpannerBackupRestore\]|\[CloudSQLReplicator\]|\[Root\])/ # If no tag is matched run everything
     script: "./CloudSpannerBackupRestore/travis/run_e2e_tests.sh --test_suite=Avro --project=${E2E_TEST_PROJECT_NAME} --bucket=${E2E_TEST_BUCKET} --database=${E2E_TEST_DATABASE}"


### PR DESCRIPTION
[Root] Updating Travis config so that each project has it's own build stages.
I had originally misinterpreted how travis conditionals work and, they are
used to determine whether a stage is run or not therefore, you can't
have multiple conditions on the same build stage and it's just better
and cleaner to split build stages per project.