### PR TITLE
add auto value annotation processor to the gradle build

### DIFF
--- a/BigQueryWorkloadTester/build.gradle
+++ b/BigQueryWorkloadTester/build.gradle
@@ -38,6 +38,8 @@ dependencies {
   compile group: 'com.google.guava', name: 'guava', version:'20.0'
   compile group: 'org.yaml', name: 'snakeyaml', version: '1.23'
 
+  annotationProcessor group: 'com.google.auto.value', name: "auto-value", version: '1.6.3'
+
   testCompile group: 'com.google.guava', name: 'guava-testlib', version: '27.0.1-jre'
   testCompile group: 'org.mockito', name: 'mockito-core', version:'2.23.4'
   testCompile group: 'junit', name: 'junit', version:'4.12'


### PR DESCRIPTION
Without the annotation processor the build fails with an error like this:
BigQueryResult.java:27: error: package AutoValue_BigQueryResult does not exist

See https://github.com/google/auto/blob/master/value/userguide/index.md