### PR TITLE
treat query files as entire scripts or multiline queries

### DIFF
--- a/BigQueryWorkloadTester/build.gradle
+++ b/BigQueryWorkloadTester/build.gradle
@@ -26,13 +26,14 @@ targetCompatibility = 1.8
 
 repositories {
      maven { url "https://repository.apache.org/content/repositories/snapshots/" }
-     maven { url "http://repo.maven.apache.org/maven2" }
+     maven { url "https://repo.maven.apache.org/maven2" }
 }
 
 dependencies {
   compile group: 'com.google.api', name: 'gax-grpc', version: '1.37.0'
   compile group: 'com.google.auto.value', name: 'auto-value', version: '1.6.3'
   compile group: 'com.google.auto.value', name: 'auto-value-annotations', version: '1.6.3'
+  annotationProcessor group: 'com.google.auto.value', name: 'auto-value', version: '1.6.3'
   compile group: 'com.google.cloud', name: 'google-cloud-bigquery', version:'1.56.0'
   compile group: 'com.google.code.gson', name: 'gson', version: '2.8.5'
   compile group: 'com.google.guava', name: 'guava', version:'20.0'

--- a/BigQueryWorkloadTester/src/main/java/com/google/cloud/pontem/config/WorkloadSettings.java
+++ b/BigQueryWorkloadTester/src/main/java/com/google/cloud/pontem/config/WorkloadSettings.java
@@ -108,17 +108,17 @@ public class WorkloadSettings {
     List<String> queriesFromFiles = new ArrayList<>();
 
     for (String queryFile : queryFiles) {
-      queriesFromFiles.addAll(readQueryFile(queryFile));
+      queriesFromFiles.add(readQueryFile(queryFile));
     }
 
     return queriesFromFiles;
   }
 
-  private List<String> readQueryFile(final String queryFile) {
-    List<String> queries = new ArrayList<>();
+  private String readQueryFile(final String queryFile) {
+    List<String> queryLines = new ArrayList<>();
 
     try {
-      queries =
+      queryLines =
           Resources.readLines(
               Resources.getResource(queryFile),
               // TODO(ldanielmadariaga): Handle other charsets
@@ -128,6 +128,6 @@ public class WorkloadSettings {
       logger.log(Level.FINE, "Failed to write to query files: ", e);
     }
 
-    return queries;
+    return String.join("\n", queryLines);
   }
 }


### PR DESCRIPTION
Fixes #244 

Read all lines in the query file, and join them to create a single
query or script.